### PR TITLE
feat: Neon Local integration for ephemeral branch development

### DIFF
--- a/.env.share
+++ b/.env.share
@@ -2,6 +2,13 @@
 #/            public-key encryption for .env files          /
 #/       [how it works](https://dotenvx.com/encryption)     /
 #/----------------------------------------------------------/
+DOTENV_PUBLIC_KEY_SHARE="037d4247648eca6ad28e8fdd736e50fbad21dbbeb9aa2edfd9a38b947e66bff95e"
+
+# .env.share
+#/-------------------[DOTENV_PUBLIC_KEY]--------------------/
+#/            public-key encryption for .env files          /
+#/       [how it works](https://dotenvx.com/encryption)     /
+#/----------------------------------------------------------/
 DOTENV_PUBLIC_KEY_LOCAL="037d4247648eca6ad28e8fdd736e50fbad21dbbeb9aa2edfd9a38b947e66bff95e"
 
 # .env.local
@@ -16,3 +23,5 @@ CLOUDINARY_API_SECRET="encrypted:BBRIrJOrBMBbCZWPI30mXBygQniOVZYxxXSJkZsSUgEuFls
 NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME="encrypted:BE1BbOmDZBKvqTpqRlXhOUL6l3Xia57d/HbNgI+NAaHjcPV1w/WEqilPMlxp0QNjwgVwQ41q7N8/slYB222mgKec9XzpKGxO3zKl38PvIzzfGcDvz1EdMxw8YWfRHOy5cMuF1IAStgKa4A=="
 BETTER_AUTH_SECRET="encrypted:BDdknzey2knnTcEfga5zJa3Z++BkhMQYUtczphePwrJ7EViJCrbnMI9fCtZFnX0RFp+kwxyQL5N84VhcX+rbu2uKFC8iQh/Rj8dZ2mthOWIn4ZaTzO0cNdUfj4emjj4XNYx/4ivSH38eF5rSO5yIa5ick0WuxqHwRcgkKehJNsdxIa6WHZsB63m4HUdq"
 BETTER_AUTH_URL="encrypted:BA+xhKfRYuTRWcMjrKxpnQvg2mOmTCTt4ErWSL9Q9jWrs+G4/8HcmJlJfcSG4P5g9qwn4qUZlTpPkSyBi6GB9LYsY62t+DRVUc6WldhrVIwSZ8Z3T2X0/eo3vQDfl1ovtWfjpJz3hTuCbAPkBVURGtlvuQXiiw=="
+NEON_PROJECT_ID="encrypted:BKU67ANSp+i/+MBLN0pKFdzIxT/TK4QA7Wr9siT2JFJfikcHjxqVTPE6z2vGtYxHXAZFTcWMYaRqyeBd33LroB/NrsblZisjc1cT+pZaK8ScMcyG3l69XpHTB2cz1fGe0fKGItHampGZo+kWJmMJEHu9pw=="
+PARENT_BRANCH_ID="encrypted:BDTkff8uJRyCMjbSuQkH3TGPT6kuxEsGVEY3Xclx16w2/G0SSF90wLri3VrDrRgTkINlZdhH1v7iZYbnC+/Bt+jerQZHXIeqtLu7T/FvluYC5Ad/qkrN/+2fdFZkZdtjWoKaE7nsdt7vRkNH5wdC0PXTUxL+X/YSKA=="

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env.keys
+.env.local
 
 # vercel
 .vercel
@@ -44,3 +45,6 @@ next-env.d.ts
 .cursor/debug.log
 
 .claude/*.local.*
+
+# Neon Local
+.neon_local/

--- a/bin/dev
+++ b/bin/dev
@@ -1,11 +1,28 @@
 #!/bin/bash
 
 # Docker Composeを使用して開発環境を起動するスクリプト
-# このスクリプトは、Next.jsアプリとStorybookの両方を含む完全な開発環境を起動します
+# Neon Local でエフェメラルブランチを自動作成し、Next.jsアプリと接続します
+#
+# 必要な環境変数（.env.local に設定）:
+#   - NEON_API_KEY: Neon API キー
+#   - NEON_PROJECT_ID: Neon プロジェクト ID
+#   - PARENT_BRANCH_ID: 親ブランチ ID（develop など）
+#
 # 使用方法: ./bin/dev
 
+set -e
+
+# dotenvx コマンドを決定
+if command -v dotenvx &> /dev/null; then
+  DOTENVX="dotenvx"
+else
+  DOTENVX="npx @dotenvx/dotenvx"
+fi
+
 echo "🚀 開発環境を起動しています..."
-echo "🔹 Next.jsアプリ: http://localhost:3000"
+echo "🔹 Neon Local: エフェメラルブランチを自動作成"
+echo "🔹 Next.js アプリ: http://localhost:3000"
 echo ""
 
-docker compose up
+# dotenvx で環境変数を展開し、docker compose up を実行
+exec $DOTENVX run -f .env.local -- docker compose up -d

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# 開発環境セットアップスクリプト
+# .env.share から .env.local を生成し、NEON_API_KEY を設定します
+#
+# 使用方法: ./bin/setup
+
+set -e
+
+echo "🔧 開発環境をセットアップしています..."
+
+# .env.local が既に存在する場合は確認
+if [ -f .env.local ]; then
+  read -p "⚠️  .env.local が既に存在します。上書きしますか？ [y/N]: " confirm
+  if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+    echo "キャンセルしました"
+    exit 0
+  fi
+fi
+
+# .env.share から .env.local をコピー
+cp .env.share .env.local
+echo "✅ .env.share → .env.local をコピーしました"
+
+# NEON_API_KEY を設定
+echo ""
+echo "Neon API キーを設定します。"
+echo "キーは https://console.neon.tech/app/settings/api-keys で取得できます。"
+echo ""
+read -p "NEON_API_KEY: " neon_api_key
+
+if [ -z "$neon_api_key" ]; then
+  echo "⚠️  NEON_API_KEY が空です。後で手動で設定してください:"
+  echo "   npx dotenvx set NEON_API_KEY \"your-api-key\" -f .env.local"
+else
+  npx dotenvx set NEON_API_KEY "$neon_api_key" -f .env.local
+  echo "✅ NEON_API_KEY を設定しました"
+fi
+
+echo ""
+echo "🎉 セットアップ完了！"
+echo ""
+echo "開発サーバーを起動するには:"
+echo "  ./bin/dev"

--- a/compose.yml
+++ b/compose.yml
@@ -1,4 +1,16 @@
 services:
+  db:
+    image: neondatabase/neon_local:latest
+    ports:
+      - "5432:5432"
+    environment:
+      NEON_API_KEY: ${NEON_API_KEY}
+      NEON_PROJECT_ID: ${NEON_PROJECT_ID}
+      PARENT_BRANCH_ID: ${PARENT_BRANCH_ID}
+    volumes:
+      - ./.neon_local:/tmp/.neon_local
+      - ./.git/HEAD:/tmp/.git/HEAD:ro,consistent
+
   app:
     build:
       context: .
@@ -10,9 +22,12 @@ services:
       - .:/app
       - /app/.next
       - node_modules:/app/node_modules
-    env_file:
-      - .env.local
-    environment: 
+      - ./.env.keys:/app/.env.keys:ro
+    environment:
       - NODE_ENV=development
+      - NEON_LOCAL_HOST=db
+    depends_on:
+      - db
+
 volumes:
   node_modules:

--- a/docs/neon-local-setup.md
+++ b/docs/neon-local-setup.md
@@ -1,0 +1,115 @@
+# Neon Local 開発環境セットアップ
+
+`./bin/dev` で自動的に Neon のエフェメラルブランチが作成され、開発環境が構築されます。
+
+## 仕組み
+
+```
+./bin/dev
+    │
+    ├─► db コンテナ (neon_local)
+    │      └─► Neon クラウドにエフェメラルブランチを自動作成
+    │
+    └─► app コンテナ (Next.js)
+           └─► db コンテナ経由でエフェメラルブランチに接続
+```
+
+- コンテナ起動時：親ブランチ（development）からエフェメラルブランチを自動作成
+- コンテナ終了時：エフェメラルブランチを自動削除
+
+## 前提条件
+
+1. Neon プロジェクトへのアクセス権限
+2. Docker Desktop がインストール済み
+3. `.env.keys` ファイル（チームリードから取得）
+
+**Mac の場合**: Docker Desktop の設定で VM を **gRPC FUSE** に変更してください（VirtioFS にバグがあるため）。
+
+## セットアップ
+
+### 1. Neon API キーの取得
+
+1. [Neon Console](https://console.neon.tech) にログイン
+2. Account Settings → API Keys → Create new API Key
+3. キーをコピー
+
+### 2. セットアップスクリプトの実行
+
+```bash
+./bin/setup
+```
+
+このスクリプトは以下を行います：
+1. `.env.share` から `.env.local` を生成
+2. 対話形式で `NEON_API_KEY` を設定
+
+### 3. 開発サーバーの起動
+
+```bash
+./bin/dev
+```
+
+これだけで：
+1. Neon にエフェメラルブランチが作成される
+2. Next.js アプリがそのブランチに接続
+3. http://localhost:3000 で開発開始
+
+### 4. 終了
+
+```bash
+# Ctrl+C または別ターミナルで
+docker compose down
+```
+
+エフェメラルブランチは自動削除されます。
+
+## 環境変数ファイルの構成
+
+| ファイル | 用途 | Git 管理 |
+|---------|------|---------|
+| `.env.share` | 共有環境変数（NEON_API_KEY 以外） | Yes |
+| `.env.local` | 個人環境変数（NEON_API_KEY 含む） | No |
+| `.env.keys` | 復号キー | No（別途共有） |
+
+## Git ブランチ連携
+
+Neon Local は Git ブランチごとに異なるデータベースブランチを作成できます。
+
+`compose.yml` で以下のボリュームマウントが設定されています：
+
+```yaml
+volumes:
+  - ./.neon_local:/tmp/.neon_local
+  - ./.git/HEAD:/tmp/.git/HEAD:ro,consistent
+```
+
+これにより、Git ブランチを切り替えると自動的に対応する Neon ブランチに切り替わります。
+
+## トラブルシューティング
+
+### db コンテナが起動しない
+
+- `NEON_API_KEY` が正しく設定されているか確認
+- Docker Desktop が起動しているか確認
+- `npx dotenvx get -f .env.local` で環境変数を確認
+
+### 接続エラー
+
+- db コンテナのログを確認: `docker compose logs db`
+- Neon Dashboard でブランチが作成されているか確認
+
+### Mac で動作しない
+
+Docker Desktop → Settings → General → Virtual Machine options で **gRPC FUSE** を選択
+
+### NEON_API_KEY を再設定したい
+
+```bash
+npx dotenvx set NEON_API_KEY "your-new-api-key" -f .env.local
+```
+
+## 参考リンク
+
+- [Neon Local - 公式ドキュメント](https://neon.com/docs/local/neon-local)
+- [Docker Hub - neondatabase/neon_local](https://hub.docker.com/r/neondatabase/neon_local)
+- [Guide: Neon Local with Docker Compose](https://neon.com/guides/neon-local-docker-compose-javascript)

--- a/src/infrastructure/db/index.ts
+++ b/src/infrastructure/db/index.ts
@@ -1,9 +1,24 @@
-import { neon } from "@neondatabase/serverless";
+import { neon, neonConfig } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
 
-if (!process.env.NETLIFY_DATABASE_URL) {
-  throw new Error("NETLIFY_DATABASE_URL environment variable is not set");
+// Neon Local 接続設定（開発環境）
+if (process.env.NEON_LOCAL_HOST) {
+  neonConfig.fetchEndpoint = `http://${process.env.NEON_LOCAL_HOST}:5432/sql`;
+  neonConfig.useSecureWebSocket = false;
+  neonConfig.pipelineTLS = false;
+  neonConfig.pipelineConnect = "password";
 }
 
-const sql = neon(process.env.NETLIFY_DATABASE_URL);
+// 開発環境: Neon Local、本番環境: NETLIFY_DATABASE_URL
+const connectionString = process.env.NEON_LOCAL_HOST
+  ? `postgres://neon:npg@${process.env.NEON_LOCAL_HOST}:5432/neondb`
+  : process.env.NETLIFY_DATABASE_URL;
+
+if (!connectionString) {
+  throw new Error(
+    "Database connection not configured. Set NETLIFY_DATABASE_URL or NEON_LOCAL_HOST.",
+  );
+}
+
+const sql = neon(connectionString);
 export const db = drizzle(sql, { casing: "snake_case" });


### PR DESCRIPTION
## Summary

- `./bin/dev` で自動的に Neon エフェメラルブランチを作成・削除する開発環境を構築
- 環境変数ファイルを共有用 (`.env.share`) と個人用 (`.env.local`) に分離
- 開発者オンボーディング用の `./bin/setup` スクリプトを追加

## 変更内容

- **compose.yml**: `neon_local` サービスを追加
- **src/infrastructure/db/index.ts**: Neon Local プロキシ経由の接続をサポート
- **bin/dev**: dotenvx で環境変数を展開して docker compose up を実行
- **bin/setup**: `.env.share` から `.env.local` を生成し、NEON_API_KEY を設定
- **.env.share**: 共有環境変数（NEON_API_KEY 以外）
- **docs/neon-local-setup.md**: セットアップドキュメント

## 開発者の流れ

```bash
./bin/setup      # 初回セットアップ（NEON_API_KEY 設定）
./bin/dev        # 開発サーバー起動（エフェメラルブランチ自動作成）
docker compose down  # 終了（エフェメラルブランチ自動削除）
```

## Test plan

- [ ] `./bin/setup` で `.env.local` が生成されること
- [ ] `./bin/dev` で db/app コンテナが起動すること
- [ ] Neon Dashboard でエフェメラルブランチが作成されること
- [ ] `docker compose down` でブランチが削除されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)