### PR TITLE
fix: Claude Code Review の allowedTools 設定を修正

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,7 +32,24 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          claude_args: '--allowedTools "Bash(pnpm check)"'
+          claude_args: >-
+            --allowedTools
+            "Bash(pnpm *)"
+            "Bash(node *)"
+            "Bash(cat *)"
+            "Bash(head *)"
+            "Bash(tail *)"
+            "Bash(sed *)"
+            "Bash(awk *)"
+            "Bash(wc *)"
+            "Bash(ls *)"
+            "Bash(find *)"
+            "Bash(grep *)"
+            "Bash(gh pr view *)"
+            "Bash(gh api *)"
+            "Bash(gh diff *)"
+            "mcp__github_comment__update_claude_comment"
+            "mcp__github_inline_comment__create_inline_comment"
           prompt: |
             /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
## 概要

Claude Code Review の GitHub Actions ワークフローで、`--allowedTools` の設定が厳しすぎて PRにレビューコメントが投稿されない問題を修正。

## 変更内容

- agentモードで必要なMCPツールを `allowedTools` に追加
  - `mcp__github_comment__update_claude_comment` — レビューコメント投稿用
  - `mcp__github_inline_comment__create_inline_comment` — インラインコメント投稿用
- レビューに必要なBashコマンドを許可リストに追加
  - `pnpm *` — 静的解析（`pnpm check` 等）
  - `sed`, `awk`, `cat`, `head`, `tail` — 大きなdiffファイルの部分読み取り
  - `gh pr view`, `gh api` — PR情報取得
  - `node`, `ls`, `find`, `grep`, `wc` — コード探索・バージョン確認

### 根本原因

1. **MCPサーバー未起動**: agentモードでは `allowedTools` に `mcp__github_*` が含まれていないとPRコメント用MCPサーバーが起動しない。元の設定には `Bash(pnpm check)` のみだったため、レビュー投稿手段がなかった
2. **Bash制限過多**: diff読み取り（`sed`/`awk`）やPR情報取得（`gh`）が全てブロックされ、レビュー内容の生成も不十分だった

参考: https://github.com/syosyo10337/soypoy-portal/actions/runs/22101339886 （PR #43 で19ターン・$8消費したがレビュー投稿ゼロ）

## テスト

- 次回のPR作成時にClaude Code Reviewが正常にレビューコメントを投稿できることを確認する

## スクリーンショット

N/A（CI設定変更のみ）