### PR TITLE
fix: Claude Code Review の allowedTools 権限を最小化

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,9 @@ jobs:
           claude_args: >-
             --allowedTools
             "Bash(pnpm *)"
-            "Bash(node *)"
+            "Bash(node -e *)"
+            "Bash(node -p *)"
+            "Bash(node --version)"
             "Bash(cat *)"
             "Bash(head *)"
             "Bash(tail *)"
@@ -46,8 +48,7 @@ jobs:
             "Bash(find *)"
             "Bash(grep *)"
             "Bash(gh pr view *)"
-            "Bash(gh api *)"
-            "Bash(gh diff *)"
+            "Bash(gh pr diff *)"
             "mcp__github_comment__update_claude_comment"
             "mcp__github_inline_comment__create_inline_comment"
           prompt: |


### PR DESCRIPTION
## 概要

Claude Code Review の GitHub Actions ワークフローで、`--allowedTools` の設定が厳しすぎてPRにレビューコメントが投稿されない問題を修正し、許可するコマンドを最小権限に絞った。

## 変更内容

- agentモードで必要なMCPツールを `allowedTools` に追加
  - `mcp__github_comment__update_claude_comment` — レビューコメント投稿用
  - `mcp__github_inline_comment__create_inline_comment` — インラインコメント投稿用
- レビューに必要なBashコマンドを最小限の許可リストに追加
  - `pnpm *` — 静的解析（`pnpm check` 等）
  - `node -e`, `node -p`, `node --version` — インライン評価・バージョン確認のみ（`node *` は避ける）
  - `sed`, `awk`, `cat`, `head`, `tail` — 大きなdiffファイルの部分読み取り
  - `gh pr view`, `gh pr diff` — PR情報取得（読み取り専用）
  - `ls`, `find`, `grep`, `wc` — コード探索
- セキュリティ上の理由で除外したもの
  - `Bash(gh api *)` — 任意のHTTPメソッド（POST/DELETE等）が実行可能なため削除。MCPツール + `gh pr view` で代替
  - `Bash(node *)` → `node -e`/`node -p`/`node --version` に限定。任意スクリプト実行を防止

### 根本原因

1. **MCPサーバー未起動**: agentモードでは `allowedTools` に `mcp__github_*` が含まれていないとPRコメント用MCPサーバーが起動しない。元の設定には `Bash(pnpm check)` のみだったため、レビュー投稿手段がなかった
2. **Bash制限過多**: diff読み取り（`sed`/`awk`）やPR情報取得（`gh`）が全てブロックされ、レビュー内容の生成も不十分だった

参考: https://github.com/syosyo10337/soypoy-portal/actions/runs/22101339886 （PR #43 で19ターン・$8消費したがレビュー投稿ゼロ）

## テスト

- 次回のPR作成時にClaude Code Reviewが正常にレビューコメントを投稿できることを確認する

## スクリーンショット

N/A（CI設定変更のみ）