### PR TITLE
feat: events ページに Suspense + skeleton ローディング UI を追加

### DIFF
--- a/src/app/(user)/events/[id]/loading.tsx
+++ b/src/app/(user)/events/[id]/loading.tsx
@@ -1,0 +1,46 @@
+import { PageTitle } from "@/components/PageTitle";
+import { Skeleton } from "@/components/shadcn/skeleton";
+import { cn } from "@/utils/cn";
+
+export default function EventDetailLoading() {
+  return (
+    <div className={cn("container mx-auto max-w-5xl", "px-8 md:px-16 py-8")}>
+      <PageTitle title="Events" />
+      {/* Breadcrumb skeleton */}
+      <div className="flex items-center gap-2 mb-2">
+        <Skeleton className="h-4 w-16" />
+        <Skeleton className="h-4 w-4" />
+        <Skeleton className="h-4 w-32" />
+      </div>
+
+      <div
+        className={cn(
+          "grid grid-cols-1 md:grid-cols-2",
+          "gap-4 md:gap-8",
+          "mt-6",
+          "font-display",
+        )}
+      >
+        {/* Date */}
+        <div className="order-1">
+          <Skeleton className="h-10 md:h-12 w-40" />
+        </div>
+        {/* Title */}
+        <div className="order-2">
+          <Skeleton className="h-8 md:h-10 w-full" />
+        </div>
+        {/* Thumbnail */}
+        <div className="order-3">
+          <Skeleton className="w-full aspect-insta" />
+        </div>
+        {/* Description */}
+        <div className="order-4 space-y-2">
+          <Skeleton className="h-5 w-full" />
+          <Skeleton className="h-5 w-full" />
+          <Skeleton className="h-5 w-3/4" />
+          <Skeleton className="h-5 w-1/2" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(user)/events/_components/EventsContentSkeleton.tsx
+++ b/src/app/(user)/events/_components/EventsContentSkeleton.tsx
@@ -1,0 +1,29 @@
+import { Skeleton } from "@/components/shadcn/skeleton";
+import { EventListSkeleton } from "./EventList/EventListSkeleton";
+
+export function EventsContentSkeleton() {
+  return (
+    <>
+      <EventListSkeleton />
+      <ScheduleAnnouncementSkeleton />
+    </>
+  );
+}
+
+function ScheduleAnnouncementSkeleton() {
+  return (
+    <div className="mt-8 md:mt-12">
+      <Skeleton className="h-7 md:h-8 w-48 mx-auto mb-2" />
+      <Skeleton className="h-4 md:h-5 w-full lg:w-96 lg:mx-auto mb-4" />
+      <div className="flex flex-wrap gap-2 lg:justify-center">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton
+            // biome-ignore lint/suspicious/noArrayIndexKey: スケルトンのため影響なし
+            key={i}
+            className="w-[calc((100%-32px)/4)] sm:w-[calc((100%-40px)/6)] md:w-[calc((100%-56px)/8)] lg:w-[calc((100%-72px)/10)] aspect-square"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(user)/events/error.tsx
+++ b/src/app/(user)/events/error.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { PageTitle } from "@/components/PageTitle";
+import { cn } from "@/utils/cn";
+
+export default function EventsError({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className={cn("container mx-auto max-w-5xl", "px-12 md:px-16 py-8")}>
+      <PageTitle title="EVENTS" subtitle="Monthly Lineup" />
+      <div className="flex flex-col items-center gap-6 py-16 text-soypoy-secondary font-display">
+        <p className="text-lg md:text-xl font-semibold">
+          データの読み込みに失敗しました
+        </p>
+        <p className="text-sm md:text-base text-soypoy-muted">
+          しばらくしてからもう一度お試しください
+        </p>
+        <button
+          type="button"
+          onClick={reset}
+          className={cn(
+            "px-6 py-2 rounded-md",
+            "bg-soypoy-secondary text-soypoy-main",
+            "text-sm font-semibold",
+            "hover:opacity-80 transition-opacity",
+          )}
+        >
+          再読み込み
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

Neon DB のコールドスタートにより `/events` や `/events/[id]` のデータ取得が遅く、白い画面が長時間表示される問題を改善。Suspense + skeleton UI でローディング状態を表示するようにした。

## 変更内容

- `/events` ページのデータ取得を async コンポーネント `EventsContent` に分離し、`<Suspense>` で包むことで `PageTitle` と `MonthNavigation` を即時描画するように修正
- `EventsContentSkeleton` を新規作成（`EventListSkeleton` + `ScheduleAnnouncementSkeleton`）
- `/events/[id]` に `loading.tsx` を追加（詳細ページ全体のスケルトン UI）
- `/events` に `error.tsx` を追加（DB 接続エラー等のフォールバック + リトライボタン）

## テスト

- `pnpm check`（tsc + lint + format）通過を確認

## スクリーンショット

<!-- UI変更がある場合、スクリーンショットを添付 -->