### PR TITLE
feat: サイドメニューのネストメニューをアコーディオン化

### DIFF
--- a/src/components/Header/NavItem.tsx
+++ b/src/components/Header/NavItem.tsx
@@ -1,4 +1,9 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
 import Link from "next/link";
+import { useState } from "react";
 import { SheetClose } from "@/components/shadcn/sheet";
 import { cn } from "@/utils/cn";
 import type { NavItem } from "./constant";
@@ -11,22 +16,54 @@ interface NavMenuItemProps {
 }
 
 export function NavMenuItem({ item }: NavMenuItemProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const hasChildren = item.children && item.children.length > 0;
+
   return (
     <li>
-      <SheetClose asChild>
-        <Link
-          href={item.href}
-          className={cn("block text-2xl py-3 px-4", navLinkStyle)}
-        >
-          {item.name}
-        </Link>
-      </SheetClose>
-      {item.children && (
-        <ul className="space-y-2 pl-4">
-          {item.children.map((child) => (
-            <SubNavItem key={child.name} child={child} />
-          ))}
-        </ul>
+      <div className="flex items-center">
+        <SheetClose asChild>
+          <Link
+            href={item.href}
+            className={cn("block text-2xl py-3 px-4 flex-1", navLinkStyle)}
+          >
+            {item.name}
+          </Link>
+        </SheetClose>
+        {hasChildren && (
+          <button
+            type="button"
+            onClick={() => setIsOpen((prev) => !prev)}
+            className="p-2 active:opacity-70"
+            aria-label={isOpen ? "サブメニューを閉じる" : "サブメニューを開く"}
+            aria-expanded={isOpen}
+          >
+            <motion.span
+              className="block"
+              animate={{ rotate: isOpen ? 180 : 0 }}
+              transition={{ duration: 0.25, ease: "easeInOut" }}
+            >
+              <ChevronDown className="size-5" strokeWidth={2} />
+            </motion.span>
+          </button>
+        )}
+      </div>
+      {hasChildren && (
+        <AnimatePresence initial={false}>
+          {isOpen && (
+            <motion.ul
+              className="space-y-2 pl-4 pb-4 overflow-hidden"
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: "auto", opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ duration: 0.25, ease: "easeInOut" }}
+            >
+              {item.children?.map((child) => (
+                <SubNavItem key={child.name} child={child} />
+              ))}
+            </motion.ul>
+          )}
+        </AnimatePresence>
       )}
     </li>
   );

--- a/src/components/Header/NavMenu.tsx
+++ b/src/components/Header/NavMenu.tsx
@@ -32,7 +32,7 @@ export function NavMenu({ navItems }: { navItems: NavItem[] }) {
       </SheetTrigger>
       <SheetContent
         side="right"
-        className="w-54 md:w-64 h-full bg-soypoy-main border-none p-0 [&>button]:text-soypoy-secondary [&>button]:hover:bg-black/5"
+        className="w-64 md:w-72 h-full bg-soypoy-main border-none p-0 [&>button]:text-soypoy-secondary [&>button]:hover:bg-black/5"
       >
         <SheetHeader className="absolute top-0 left-0 w-0 h-0 overflow-hidden">
           <SheetTitle className="sr-only">ナビゲーションメニュー</SheetTitle>
@@ -45,7 +45,7 @@ export function NavMenu({ navItems }: { navItems: NavItem[] }) {
             "md:py-16 md:px-10",
           )}
         >
-          <ul className="space-y-4">
+          <ul className="divide-y-2 divide-soypoy-secondary/20">
             {navItems.map((item) => (
               <NavMenuItem key={item.name} item={item} />
             ))}


### PR DESCRIPTION
## 概要
サイドメニューのネストされたサブメニュー（About, What's Up）をアコーディオン開閉式に変更。

## 変更内容

- chevron ボタンでサブメニューの開閉をトグルできるように変更
- Motion (AnimatePresence) で高さ・opacity のスライドアニメーション追加
- chevron アイコンの 180° 回転アニメーション追加
- 親メニュー間に 2px border (`divide-y-2`) を追加
- サイドメニュー幅を拡大 (`w-54 md:w-64` → `w-64 md:w-72`)
- アクセシビリティ対応 (`aria-expanded`, `aria-label`)

## テスト

- サブメニューの開閉アニメーションが正しく動作すること
- 親メニューのリンク遷移が引き続き動作すること
- children のないメニュー（Events）が従来通り表示されること
- SP / PC で幅・レイアウトが崩れないこと

## スクリーンショット
<!-- UI変更がある場合、スクリーンショットを添付 -->