### PR TITLE
feat: サイドメニューの hover スタイルとサブメニュー表示を改善

### DIFF
--- a/src/components/Header/NavItem.tsx
+++ b/src/components/Header/NavItem.tsx
@@ -23,10 +23,7 @@ export function NavMenuItem({ item }: NavMenuItemProps) {
     <li>
       <div className={cn("flex items-center", navLinkStyle)}>
         <SheetClose asChild>
-          <Link
-            href={item.href}
-            className="block text-2xl py-3 px-4 flex-1"
-          >
+          <Link href={item.href} className="block text-2xl py-3 px-4 flex-1">
             {item.name}
           </Link>
         </SheetClose>


### PR DESCRIPTION
## 概要
サイドメニューの hover スタイルを下線から背景色変更に変更し、サブメニューのドットマーカーを削除。

## 変更内容

- hover スタイルを下線表示から背景色変更 (`bg-soypoy-secondary/10`) に変更
- hover の背景色を親リンク + chevron 含む行全体に適用
- サブメニューのドットマーカー (•) を削除

## テスト

- 親メニュー・サブメニューの hover 背景色が行全体に適用されること
- リンク遷移・アコーディオン開閉が引き続き動作すること
- SP / PC で表示が崩れないこと

## スクリーンショット
<!-- UI変更がある場合、スクリーンショットを添付 -->