### PR TITLE
fix(404): ミラーボールアニメーション レビュー対応

### DIFF
--- a/src/app/_components/NotFound/MirrorBall.tsx
+++ b/src/app/_components/NotFound/MirrorBall.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Image from "next/image";
-import { useHydrationSafeReducedMotion } from "@/hooks/useHydrationSafeReducedMotion";
 import { mirrorballImage } from "./assets";
 
 interface MirrorBallProps {
@@ -28,8 +27,6 @@ const GLINTS: Array<{
 ];
 
 export function MirrorBall({ className }: MirrorBallProps) {
-  const shouldReduceMotion = useHydrationSafeReducedMotion();
-
   return (
     <div
       className={`relative select-none ${className ?? ""}`}
@@ -41,27 +38,26 @@ export function MirrorBall({ className }: MirrorBallProps) {
         className="w-full h-auto"
         fetchPriority="high"
       />
-      {!shouldReduceMotion && (
-        <div className="mirrorball-glints">
-          {GLINTS.map((glint) => (
-            <div
-              key={glint.id}
-              className="mirrorball-glint"
-              style={{
-                top: glint.top,
-                width: `${glint.size}px`,
-                height: `${glint.size}px`,
-                animationName:
-                  glint.direction === "ltr"
-                    ? "mirrorball-glint-ltr"
-                    : "mirrorball-glint-rtl",
-                animationDuration: `${glint.duration}s`,
-                animationDelay: `${glint.delay}s`,
-              }}
-            />
-          ))}
-        </div>
-      )}
+      {/* reduced-motion は CSS @media で制御するため JS チェック不要 */}
+      <div className="mirrorball-glints">
+        {GLINTS.map((glint) => (
+          <div
+            key={glint.id}
+            className="mirrorball-glint"
+            style={{
+              top: glint.top,
+              width: `${glint.size}px`,
+              height: `${glint.size}px`,
+              animationName:
+                glint.direction === "ltr"
+                  ? "mirrorball-glint-ltr"
+                  : "mirrorball-glint-rtl",
+              animationDuration: `${glint.duration}s`,
+              animationDelay: `${glint.delay}s`,
+            }}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/assets/styles/mirrorball.css
+++ b/src/assets/styles/mirrorball.css
@@ -7,10 +7,12 @@
   border-radius: 50%;
   overflow: hidden;
   pointer-events: none;
+  container-type: inline-size;
 }
 
 .mirrorball-glint {
   position: absolute;
+  left: 0;
   border-radius: 50%;
   background: radial-gradient(
     circle,
@@ -18,14 +20,16 @@
     rgba(255, 255, 255, 0.5) 35%,
     rgba(255, 255, 255, 0) 100%
   );
-  transform: translateY(-50%);
+  /* CSS translate プロパティで縦位置を調整（transform とは独立して合成される） */
+  translate: 0 -50%;
+  will-change: transform;
   animation-timing-function: linear;
   animation-iteration-count: infinite;
 }
 
 @keyframes mirrorball-glint-ltr {
-  0% {
-    left: -16px;
+  from {
+    transform: translateX(-20px);
     opacity: 0;
   }
   5% {
@@ -34,15 +38,15 @@
   95% {
     opacity: 1;
   }
-  100% {
-    left: calc(100% + 16px);
+  to {
+    transform: translateX(calc(100cqw + 20px));
     opacity: 0;
   }
 }
 
 @keyframes mirrorball-glint-rtl {
-  0% {
-    left: calc(100% + 16px);
+  from {
+    transform: translateX(calc(100cqw + 20px));
     opacity: 0;
   }
   5% {
@@ -51,8 +55,15 @@
   95% {
     opacity: 1;
   }
-  100% {
-    left: -16px;
+  to {
+    transform: translateX(-20px);
     opacity: 0;
+  }
+}
+
+/* filmroll と同じパターン: CSS側でも確実にモーションを止める */
+@media (prefers-reduced-motion: reduce) {
+  .mirrorball-glints {
+    display: none;
   }
 }


### PR DESCRIPTION
## 概要

PR #70 のレビュー指摘2点に対応した修正。

## 変更内容

- `left` アニメーション → `transform: translateX()` + `100cqw` に変更（GPU合成・レイアウト計算なし）
- CSS `translate` プロパティで縦位置調整（`transform` とは独立して合成）
- `@media (prefers-reduced-motion: reduce)` を CSS 側に追加（filmroll と同パターン）
- JS の `useHydrationSafeReducedMotion` チェックを削除（SSR〜hydration 直後の一瞬表示を防止）

## テスト

- 404 ページでミラーボールの光スポットが流れることを確認
- `prefers-reduced-motion: reduce` 設定時にスポットが表示されないことを確認

## スクリーンショット
<!-- UI変更がある場合、スクリーンショットを添付 -->