### PR TITLE
fix: 管理画面のSP対応（カード表示 + ページネーション）

### DIFF
--- a/src/app/admin/(authenticated)/admins/(list)/_components/AdminCardList/AdminCard.tsx
+++ b/src/app/admin/(authenticated)/admins/(list)/_components/AdminCardList/AdminCard.tsx
@@ -1,0 +1,37 @@
+import { AdminRoleBadge } from "@/components/admin/AdminRoleBadge";
+import { Avatar, AvatarFallback } from "@/components/shadcn/avatar";
+import type { AdminUserEntity } from "@/domain/entities";
+import { AdminActions } from "../AdminsTable/AdminActions";
+
+interface AdminCardProps {
+  admin: AdminUserEntity;
+}
+
+/**
+ * 管理者SPカード
+ */
+export function AdminCard({ admin }: AdminCardProps) {
+  const initials = admin.name.slice(0, 2);
+
+  return (
+    <div className="rounded-md border p-3">
+      {/* 上段: アバター + 名前 + ロール */}
+      <div className="flex items-center gap-3">
+        <Avatar className="h-10 w-10 shrink-0">
+          <AvatarFallback className="text-xs">{initials}</AvatarFallback>
+        </Avatar>
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="truncate text-sm font-medium">{admin.name}</span>
+          <span className="truncate text-xs text-muted-foreground">
+            {admin.email}
+          </span>
+        </div>
+        <AdminRoleBadge variant={admin.role} className="shrink-0" />
+      </div>
+      {/* 下段: アクション */}
+      <div className="mt-2 flex justify-end">
+        <AdminActions adminId={admin.id} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/(authenticated)/admins/(list)/_components/AdminCardList/AdminCardSkeleton.tsx
+++ b/src/app/admin/(authenticated)/admins/(list)/_components/AdminCardList/AdminCardSkeleton.tsx
@@ -1,0 +1,25 @@
+/**
+ * 管理者カードのスケルトン（3枚）
+ */
+export function AdminCardSkeleton() {
+  return (
+    <div className="flex flex-col gap-2">
+      {[1, 2, 3].map((id) => (
+        <div key={`admin-skeleton-${id}`} className="rounded-md border p-3">
+          <div className="flex items-center gap-3">
+            <div className="h-10 w-10 shrink-0 animate-pulse rounded-full bg-muted" />
+            <div className="flex flex-1 flex-col gap-1.5">
+              <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+              <div className="h-3 w-36 animate-pulse rounded bg-muted" />
+            </div>
+            <div className="h-5 w-16 animate-pulse rounded-full bg-muted" />
+          </div>
+          <div className="mt-2 flex justify-end gap-2">
+            <div className="h-8 w-8 animate-pulse rounded bg-muted" />
+            <div className="h-8 w-8 animate-pulse rounded bg-muted" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/admin/(authenticated)/admins/(list)/_components/AdminCardList/index.tsx
+++ b/src/app/admin/(authenticated)/admins/(list)/_components/AdminCardList/index.tsx
@@ -1,0 +1,27 @@
+import type { AdminUserEntity } from "@/domain/entities";
+import { AdminCard } from "./AdminCard";
+
+interface AdminCardListProps {
+  admins: AdminUserEntity[];
+}
+
+/**
+ * 管理者SPカード一覧
+ */
+export function AdminCardList({ admins }: AdminCardListProps) {
+  if (admins.length === 0) {
+    return (
+      <div className="py-8 text-center text-sm text-muted-foreground">
+        管理者がいません
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {admins.map((admin) => (
+        <AdminCard key={admin.id} admin={admin} />
+      ))}
+    </div>
+  );
+}

--- a/src/app/admin/(authenticated)/admins/(list)/_components/AdminsContent.tsx
+++ b/src/app/admin/(authenticated)/admins/(list)/_components/AdminsContent.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useList } from "@refinedev/core";
+import { Pagination } from "@/components/admin/Pagination";
+import type { AdminUserEntity } from "@/domain/entities";
+import { usePagination } from "@/hooks/usePagination";
+import { AdminCardList } from "./AdminCardList";
+import { AdminCardSkeleton } from "./AdminCardList/AdminCardSkeleton";
+import { AdminsTable } from "./AdminsTable";
+import { AdminsTableLoading } from "./AdminsTableLoading";
+
+const PAGE_SIZE = 6;
+
+/**
+ * 管理者一覧の統合コンポーネント
+ *
+ * SP: カード表示、PC: テーブル表示
+ * クライアントサイドページネーション付き
+ */
+export function AdminsContent() {
+  const { result, query } = useList<AdminUserEntity>();
+  const admins = result.data ?? [];
+  const { paginatedItems, ...pagination } = usePagination(admins, PAGE_SIZE);
+
+  if (query.isLoading) {
+    return (
+      <>
+        <div className="md:hidden">
+          <AdminCardSkeleton />
+        </div>
+        <div className="hidden md:block">
+          <AdminsTableLoading />
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      {/* SP: カード表示 */}
+      <div className="md:hidden">
+        <AdminCardList admins={paginatedItems} />
+      </div>
+      {/* PC: テーブル表示 */}
+      <div className="hidden md:block">
+        <AdminsTable admins={paginatedItems} />
+      </div>
+      {/* 共通: 件数 + ページネーション */}
+      <div className="text-sm text-muted-foreground">
+        合計 {admins.length} 件
+      </div>
+      <Pagination {...pagination} />
+    </>
+  );
+}

--- a/src/app/admin/(authenticated)/admins/(list)/_components/AdminsTable/Row.tsx
+++ b/src/app/admin/(authenticated)/admins/(list)/_components/AdminsTable/Row.tsx
@@ -16,7 +16,9 @@ export function AdminTableRow({ admin }: AdminTableRowProps) {
       <TableCell>
         <AdminRoleBadge variant={admin.role} />
       </TableCell>
-      <TableCell>{formatDateJP(admin.createdAt)}</TableCell>
+      <TableCell className="hidden md:table-cell">
+        {formatDateJP(admin.createdAt)}
+      </TableCell>
       <TableCell className="text-right">
         <AdminActions adminId={admin.id} />
       </TableCell>

--- a/src/app/admin/(authenticated)/admins/(list)/_components/AdminsTable/index.tsx
+++ b/src/app/admin/(authenticated)/admins/(list)/_components/AdminsTable/index.tsx
@@ -31,7 +31,7 @@ export function AdminsTable() {
               <TableHead>名前</TableHead>
               <TableHead>メールアドレス</TableHead>
               <TableHead>ロール</TableHead>
-              <TableHead>作成日</TableHead>
+              <TableHead className="hidden md:table-cell">作成日</TableHead>
               <TableHead className="text-right">操作</TableHead>
             </TableRow>
           </TableHeader>

--- a/src/app/admin/(authenticated)/admins/(list)/_components/AdminsTable/index.tsx
+++ b/src/app/admin/(authenticated)/admins/(list)/_components/AdminsTable/index.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useList } from "@refinedev/core";
 import {
   Table,
   TableBody,
@@ -9,46 +8,41 @@ import {
   TableRow,
 } from "@/components/shadcn/table";
 import type { AdminUserEntity } from "@/domain/entities";
-import { AdminsTableLoading } from "../AdminsTableLoading";
 import { NoAdminsRow } from "./NoAdminsRow";
 import { AdminTableRow } from "./Row";
 
-export function AdminsTable() {
-  const { result, query } = useList<AdminUserEntity>();
+interface AdminsTableProps {
+  admins: AdminUserEntity[];
+}
 
-  const admins = result.data ?? [];
-
-  if (query.isLoading) {
-    return <AdminsTableLoading />;
-  }
-
+/**
+ * 管理者一覧テーブル（PC表示用）
+ *
+ * データ取得・ローディング制御は親コンポーネント（AdminsContent）が担当
+ */
+export function AdminsTable({ admins }: AdminsTableProps) {
   return (
-    <>
-      <div className="rounded-md border">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>名前</TableHead>
-              <TableHead>メールアドレス</TableHead>
-              <TableHead>ロール</TableHead>
-              <TableHead className="hidden md:table-cell">作成日</TableHead>
-              <TableHead className="text-right">操作</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {admins.length === 0 ? (
-              <NoAdminsRow />
-            ) : (
-              admins.map((admin) => (
-                <AdminTableRow key={admin.id} admin={admin} />
-              ))
-            )}
-          </TableBody>
-        </Table>
-      </div>
-      <div className="text-sm text-muted-foreground">
-        合計 {admins.length} 件
-      </div>
-    </>
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>名前</TableHead>
+            <TableHead>メールアドレス</TableHead>
+            <TableHead>ロール</TableHead>
+            <TableHead className="hidden md:table-cell">作成日</TableHead>
+            <TableHead className="text-right">操作</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {admins.length === 0 ? (
+            <NoAdminsRow />
+          ) : (
+            admins.map((admin) => (
+              <AdminTableRow key={admin.id} admin={admin} />
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
   );
 }

--- a/src/app/admin/(authenticated)/admins/(list)/_components/AdminsTableLoading/index.tsx
+++ b/src/app/admin/(authenticated)/admins/(list)/_components/AdminsTableLoading/index.tsx
@@ -17,7 +17,7 @@ export function AdminsTableLoading() {
             <TableHead>名前</TableHead>
             <TableHead>メールアドレス</TableHead>
             <TableHead>ロール</TableHead>
-            <TableHead>作成日</TableHead>
+            <TableHead className="hidden md:table-cell">作成日</TableHead>
             <TableHead className="text-right">操作</TableHead>
           </TableRow>
         </TableHeader>
@@ -33,7 +33,7 @@ export function AdminsTableLoading() {
               <TableCell>
                 <Skeleton className="h-6 w-20" />
               </TableCell>
-              <TableCell>
+              <TableCell className="hidden md:table-cell">
                 <Skeleton className="h-4 w-24" />
               </TableCell>
               <TableCell className="text-right">

--- a/src/app/admin/(authenticated)/admins/(list)/_components/index.ts
+++ b/src/app/admin/(authenticated)/admins/(list)/_components/index.ts
@@ -1,2 +1,3 @@
+export { AdminsContent } from "./AdminsContent";
 export { AdminsTable } from "./AdminsTable";
 export { AdminsTableLoading } from "./AdminsTableLoading";

--- a/src/app/admin/(authenticated)/admins/(list)/page.tsx
+++ b/src/app/admin/(authenticated)/admins/(list)/page.tsx
@@ -3,7 +3,7 @@ import {
   ListView,
   ListViewHeader,
 } from "@/components/refine-ui/views/list-view";
-import { AdminsTable } from "./_components/AdminsTable";
+import { AdminsContent } from "./_components/AdminsContent";
 
 export const metadata: Metadata = {
   title: "管理者一覧",
@@ -13,7 +13,7 @@ export default function AdminsListPage() {
   return (
     <ListView>
       <ListViewHeader />
-      <AdminsTable />
+      <AdminsContent />
     </ListView>
   );
 }

--- a/src/app/admin/(authenticated)/admins/[id]/_components/AdminDetailCard.tsx
+++ b/src/app/admin/(authenticated)/admins/[id]/_components/AdminDetailCard.tsx
@@ -91,7 +91,7 @@ export function AdminDetailCard({ admin }: AdminDetailCardProps) {
           </div>
         </CardHeader>
         <CardContent className="space-y-6">
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
               <p className="text-sm text-muted-foreground">作成日時</p>
               <p className="font-medium">{formatDateTimeJP(admin.createdAt)}</p>
@@ -103,7 +103,7 @@ export function AdminDetailCard({ admin }: AdminDetailCardProps) {
           </div>
 
           {isSuperAdmin && (
-            <div className="flex gap-2 pt-4 border-t">
+            <div className="flex flex-col sm:flex-row gap-2 pt-4 border-t">
               <Button
                 variant="outline"
                 onClick={() => setIsResetDialogOpen(true)}

--- a/src/app/admin/(authenticated)/closed-days/_components/ClosedDaysCalendar/CalendarCell.tsx
+++ b/src/app/admin/(authenticated)/closed-days/_components/ClosedDaysCalendar/CalendarCell.tsx
@@ -26,7 +26,7 @@ export function CalendarCell({
       disabled={!isClickable}
       onClick={isClickable ? onClick : undefined}
       className={cn(
-        "aspect-square flex flex-col items-center rounded-md text-sm transition-colors pt-1.5",
+        "aspect-square flex flex-col items-center rounded-md text-xs md:text-sm transition-colors pt-1 md:pt-1.5",
         status === DayStatus.WeekDay &&
           "bg-gray-100 text-gray-400 cursor-not-allowed",
         status === DayStatus.Event &&
@@ -47,7 +47,7 @@ export function CalendarCell({
         </span>
       )}
       {status === DayStatus.Closed && (
-        <span className="text-sm font-semibold flex-1 flex items-center">
+        <span className="text-xs md:text-sm font-semibold flex-1 flex items-center">
           休業
         </span>
       )}

--- a/src/app/admin/(authenticated)/closed-days/_components/ClosedDaysCalendar/CalendarGrid.tsx
+++ b/src/app/admin/(authenticated)/closed-days/_components/ClosedDaysCalendar/CalendarGrid.tsx
@@ -49,7 +49,7 @@ export function CalendarGrid({
   return (
     <div>
       <DayLabelsRow />
-      <div className="grid grid-cols-7 gap-4">
+      <div className="grid grid-cols-7 gap-1 md:gap-4">
         {emptyCells}
         {dayCells}
       </div>

--- a/src/app/admin/(authenticated)/closed-days/_components/ClosedDaysCalendar/CalendarSkeleton.tsx
+++ b/src/app/admin/(authenticated)/closed-days/_components/ClosedDaysCalendar/CalendarSkeleton.tsx
@@ -5,7 +5,7 @@ export function CalendarSkeleton() {
     <div className="space-y-6">
       <div>
         <DayLabelsRow />
-        <div className="grid grid-cols-7 gap-4">
+        <div className="grid grid-cols-7 gap-1 md:gap-4">
           {Array.from({ length: 35 }, (_, i) => (
             <div
               // biome-ignore lint/suspicious/noArrayIndexKey: skeletonなので問題ない

--- a/src/app/admin/(authenticated)/closed-days/_components/ClosedDaysCalendar/DayLabelsRow.tsx
+++ b/src/app/admin/(authenticated)/closed-days/_components/ClosedDaysCalendar/DayLabelsRow.tsx
@@ -4,7 +4,7 @@ const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
 export function DayLabelsRow() {
   return (
-    <div className="grid grid-cols-7 gap-4 mb-1">
+    <div className="grid grid-cols-7 gap-1 md:gap-4 mb-1">
       {DAY_LABELS.map((label, index) => (
         <div
           key={label}

--- a/src/app/admin/(authenticated)/closed-days/_components/ClosedDaysCalendar/index.tsx
+++ b/src/app/admin/(authenticated)/closed-days/_components/ClosedDaysCalendar/index.tsx
@@ -36,7 +36,7 @@ export function ClosedDaysCalendar() {
   };
 
   return (
-    <div className="px-16 space-y-6">
+    <div className="px-0 md:px-8 lg:px-16 space-y-6">
       <MonthSelector
         year={currentYear}
         month={currentMonth}

--- a/src/app/admin/(authenticated)/events/(list)/_components/EventCardList/EventCard.tsx
+++ b/src/app/admin/(authenticated)/events/(list)/_components/EventCardList/EventCard.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { CldImage } from "next-cloudinary";
+import { EventStatusBadge } from "@/components/admin/EventStatusBadge";
+import type { EventEntity } from "@/domain/entities";
+import { formatDateJP } from "@/utils/date";
+import { EventActions } from "../EventsTable/EventActions";
+
+interface EventCardProps {
+  event: EventEntity;
+}
+
+/**
+ * イベントSPカード
+ *
+ * カード全体タップで詳細遷移（アクション領域除外）
+ */
+export function EventCard({ event }: EventCardProps) {
+  const router = useRouter();
+
+  const navigate = () => router.push(`/admin/events/${event.id}`);
+
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    if (target.closest("[data-actions]") || target.closest("button")) {
+      return;
+    }
+    navigate();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      const target = e.target as HTMLElement;
+      if (target.closest("[data-actions]") || target.closest("button")) {
+        return;
+      }
+      e.preventDefault();
+      navigate();
+    }
+  };
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: 内部にbutton（EventActions）を含むためdivを使用
+    <div
+      role="button"
+      tabIndex={0}
+      className="flex items-center gap-3 rounded-md border p-3 cursor-pointer active:bg-muted/50"
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+    >
+      {/* サムネイル */}
+      {event.thumbnail ? (
+        <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-md">
+          <CldImage
+            src={event.thumbnail}
+            alt={event.title}
+            width={48}
+            height={48}
+            crop="fill"
+            gravity="auto"
+            className="object-cover"
+          />
+        </div>
+      ) : (
+        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-muted text-[10px] text-white">
+          No Image
+        </div>
+      )}
+
+      {/* 情報 */}
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="truncate text-sm font-medium">{event.title}</span>
+        <span className="text-xs text-muted-foreground">
+          {formatDateJP(event.date)}
+        </span>
+        <EventStatusBadge variant={event.publicationStatus} className="w-fit" />
+      </div>
+
+      {/* アクション */}
+      <div className="shrink-0" data-actions>
+        <EventActions
+          eventId={event.id}
+          publicationStatus={event.publicationStatus}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/(authenticated)/events/(list)/_components/EventCardList/EventCardSkeleton.tsx
+++ b/src/app/admin/(authenticated)/events/(list)/_components/EventCardList/EventCardSkeleton.tsx
@@ -1,0 +1,23 @@
+/**
+ * イベントカードのスケルトン（3枚）
+ */
+export function EventCardSkeleton() {
+  return (
+    <div className="flex flex-col gap-2">
+      {[1, 2, 3].map((id) => (
+        <div
+          key={`card-skeleton-${id}`}
+          className="flex items-center gap-3 rounded-md border p-3"
+        >
+          <div className="h-12 w-12 shrink-0 animate-pulse rounded-md bg-muted" />
+          <div className="flex flex-1 flex-col gap-1.5">
+            <div className="h-4 w-36 animate-pulse rounded bg-muted" />
+            <div className="h-3 w-24 animate-pulse rounded bg-muted" />
+            <div className="h-5 w-16 animate-pulse rounded-full bg-muted" />
+          </div>
+          <div className="h-8 w-8 shrink-0 animate-pulse rounded bg-muted" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/admin/(authenticated)/events/(list)/_components/EventCardList/index.tsx
+++ b/src/app/admin/(authenticated)/events/(list)/_components/EventCardList/index.tsx
@@ -1,0 +1,27 @@
+import type { EventEntity } from "@/domain/entities";
+import { EventCard } from "./EventCard";
+
+interface EventCardListProps {
+  events: EventEntity[];
+}
+
+/**
+ * イベントSPカード一覧
+ */
+export function EventCardList({ events }: EventCardListProps) {
+  if (events.length === 0) {
+    return (
+      <div className="py-8 text-center text-sm text-muted-foreground">
+        イベントがありません
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {events.map((event) => (
+        <EventCard key={event.id} event={event} />
+      ))}
+    </div>
+  );
+}

--- a/src/app/admin/(authenticated)/events/(list)/_components/EventsContent.tsx
+++ b/src/app/admin/(authenticated)/events/(list)/_components/EventsContent.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useList } from "@refinedev/core";
+import { Pagination } from "@/components/admin/Pagination";
+import type { EventEntity } from "@/domain/entities";
+import { usePagination } from "@/hooks/usePagination";
+import { EventCardList } from "./EventCardList";
+import { EventCardSkeleton } from "./EventCardList/EventCardSkeleton";
+import { EventsTable } from "./EventsTable";
+import { EventsTableLoading } from "./EventsTableLoading";
+
+const PAGE_SIZE = 6;
+
+/**
+ * イベント一覧の統合コンポーネント
+ *
+ * SP: カード表示、PC: テーブル表示
+ * クライアントサイドページネーション付き
+ */
+export function EventsContent() {
+  const { result, query } = useList<EventEntity>();
+  const events = result.data ?? [];
+  const { paginatedItems, ...pagination } = usePagination(events, PAGE_SIZE);
+
+  if (query.isLoading) {
+    return (
+      <>
+        <div className="md:hidden">
+          <EventCardSkeleton />
+        </div>
+        <div className="hidden md:block">
+          <EventsTableLoading />
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      {/* SP: カード表示 */}
+      <div className="md:hidden">
+        <EventCardList events={paginatedItems} />
+      </div>
+      {/* PC: テーブル表示 */}
+      <div className="hidden md:block">
+        <EventsTable events={paginatedItems} />
+      </div>
+      {/* 共通: 件数 + ページネーション */}
+      <div className="text-sm text-muted-foreground">
+        合計 {events.length} 件
+      </div>
+      <Pagination {...pagination} />
+    </>
+  );
+}

--- a/src/app/admin/(authenticated)/events/(list)/_components/EventsTable/Row.tsx
+++ b/src/app/admin/(authenticated)/events/(list)/_components/EventsTable/Row.tsx
@@ -31,7 +31,7 @@ export function EventTableRow({ event }: EventTableRowProps) {
 
   return (
     <TableRow onClick={handleRowClick} className="cursor-pointer">
-      <TableCell>
+      <TableCell className="hidden md:table-cell">
         {event.thumbnail ? (
           <div className="relative w-16 h-16 rounded-md overflow-hidden">
             <CldImage
@@ -52,13 +52,13 @@ export function EventTableRow({ event }: EventTableRowProps) {
       </TableCell>
       <TableCell className="font-medium">{event.title}</TableCell>
       <TableCell>{formatDateJP(event.date)}</TableCell>
-      <TableCell>
+      <TableCell className="hidden md:table-cell">
         <Badge variant="outline">{event.type}</Badge>
       </TableCell>
       <TableCell>
         <EventStatusBadge variant={event.publicationStatus} />
       </TableCell>
-      <TableCell>
+      <TableCell className="hidden md:table-cell">
         <Badge variant={event.isPickup ? "default" : "secondary"}>
           {event.isPickup ? "ON" : "OFF"}
         </Badge>

--- a/src/app/admin/(authenticated)/events/(list)/_components/EventsTable/index.tsx
+++ b/src/app/admin/(authenticated)/events/(list)/_components/EventsTable/index.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useList } from "@refinedev/core";
 import {
   Table,
   TableBody,
@@ -9,53 +8,43 @@ import {
   TableRow,
 } from "@/components/shadcn/table";
 import type { EventEntity } from "@/domain/entities";
-import { EventsTableLoading } from "../EventsTableLoading";
 import { NoEventsRow } from "./NoEventsRow";
 import { EventTableRow } from "./Row";
 
+interface EventsTableProps {
+  events: EventEntity[];
+}
+
 /**
- * イベント一覧テーブル
+ * イベント一覧テーブル（PC表示用）
+ *
+ * データ取得・ローディング制御は親コンポーネント（EventsContent）が担当
  */
-export function EventsTable() {
-  const { result, query } = useList<EventEntity>();
-
-  const events = result.data ?? [];
-
-  if (query.isLoading) {
-    return <EventsTableLoading />;
-  }
-
+export function EventsTable({ events }: EventsTableProps) {
   return (
-    <>
-      <div className="rounded-md border">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="hidden md:table-cell">サムネイル</TableHead>
-              <TableHead>タイトル</TableHead>
-              <TableHead>日付</TableHead>
-              <TableHead className="hidden md:table-cell">種類</TableHead>
-              <TableHead>ステータス</TableHead>
-              <TableHead className="hidden md:table-cell">
-                ピックアップ
-              </TableHead>
-              <TableHead className="text-center">操作</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {events.length === 0 ? (
-              <NoEventsRow />
-            ) : (
-              events.map((event) => (
-                <EventTableRow key={event.id} event={event} />
-              ))
-            )}
-          </TableBody>
-        </Table>
-      </div>
-      <div className="text-sm text-muted-foreground">
-        合計 {events.length} 件
-      </div>
-    </>
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="hidden md:table-cell">サムネイル</TableHead>
+            <TableHead>タイトル</TableHead>
+            <TableHead>日付</TableHead>
+            <TableHead className="hidden md:table-cell">種類</TableHead>
+            <TableHead>ステータス</TableHead>
+            <TableHead className="hidden md:table-cell">ピックアップ</TableHead>
+            <TableHead className="text-center">操作</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {events.length === 0 ? (
+            <NoEventsRow />
+          ) : (
+            events.map((event) => (
+              <EventTableRow key={event.id} event={event} />
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
   );
 }

--- a/src/app/admin/(authenticated)/events/(list)/_components/EventsTable/index.tsx
+++ b/src/app/admin/(authenticated)/events/(list)/_components/EventsTable/index.tsx
@@ -31,12 +31,14 @@ export function EventsTable() {
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>サムネイル</TableHead>
+              <TableHead className="hidden md:table-cell">サムネイル</TableHead>
               <TableHead>タイトル</TableHead>
               <TableHead>日付</TableHead>
-              <TableHead>種類</TableHead>
+              <TableHead className="hidden md:table-cell">種類</TableHead>
               <TableHead>ステータス</TableHead>
-              <TableHead>ピックアップ</TableHead>
+              <TableHead className="hidden md:table-cell">
+                ピックアップ
+              </TableHead>
               <TableHead className="text-center">操作</TableHead>
             </TableRow>
           </TableHeader>

--- a/src/app/admin/(authenticated)/events/(list)/_components/EventsTableLoading/index.tsx
+++ b/src/app/admin/(authenticated)/events/(list)/_components/EventsTableLoading/index.tsx
@@ -19,19 +19,19 @@ export function EventsTableLoading() {
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead>サムネイル</TableHead>
+            <TableHead className="hidden md:table-cell">サムネイル</TableHead>
             <TableHead>タイトル</TableHead>
             <TableHead>日付</TableHead>
-            <TableHead>種類</TableHead>
+            <TableHead className="hidden md:table-cell">種類</TableHead>
             <TableHead>ステータス</TableHead>
-            <TableHead>ピックアップ</TableHead>
+            <TableHead className="hidden md:table-cell">ピックアップ</TableHead>
             <TableHead className="text-right">操作</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {[1, 2, 3].map((id) => (
             <TableRow key={`skeleton-${id}`}>
-              <TableCell>
+              <TableCell className="hidden md:table-cell">
                 <div className="h-16 w-16 bg-muted animate-pulse rounded-md" />
               </TableCell>
               <TableCell>
@@ -40,13 +40,13 @@ export function EventsTableLoading() {
               <TableCell>
                 <div className="h-5 w-24 bg-muted animate-pulse rounded" />
               </TableCell>
-              <TableCell>
+              <TableCell className="hidden md:table-cell">
                 <div className="h-6 w-16 bg-muted animate-pulse rounded-full" />
               </TableCell>
               <TableCell>
                 <div className="h-6 w-20 bg-muted animate-pulse rounded-full" />
               </TableCell>
-              <TableCell>
+              <TableCell className="hidden md:table-cell">
                 <div className="h-6 w-12 bg-muted animate-pulse rounded-full" />
               </TableCell>
               <TableCell className="text-right">

--- a/src/app/admin/(authenticated)/events/(list)/_components/index.ts
+++ b/src/app/admin/(authenticated)/events/(list)/_components/index.ts
@@ -7,5 +7,6 @@
  * - 状態表示コンポーネント（ローディング、空状態）
  */
 
+export { EventsContent } from "./EventsContent";
 export { EventsTable } from "./EventsTable";
 export { EventsTableLoading } from "./EventsTableLoading";

--- a/src/app/admin/(authenticated)/events/(list)/page.tsx
+++ b/src/app/admin/(authenticated)/events/(list)/page.tsx
@@ -3,7 +3,7 @@ import {
   ListView,
   ListViewHeader,
 } from "@/components/refine-ui/views/list-view";
-import { EventsTable } from "./_components";
+import { EventsContent } from "./_components/EventsContent";
 
 export const metadata: Metadata = {
   title: "イベント一覧",
@@ -13,7 +13,7 @@ export default function EventsListPage() {
   return (
     <ListView>
       <ListViewHeader />
-      <EventsTable />
+      <EventsContent />
     </ListView>
   );
 }

--- a/src/app/admin/(authenticated)/layout.tsx
+++ b/src/app/admin/(authenticated)/layout.tsx
@@ -21,7 +21,7 @@ export default function AuthenticatedAdminLayout({
     <Authenticated key="authenticated-admin-layout" loading={<AdminLoading />}>
       <div className="min-h-screen">
         <AdminSidebar />
-        <main className="p-16">{children}</main>
+        <main className="p-4 md:p-8 lg:p-16">{children}</main>
       </div>
     </Authenticated>
   );

--- a/src/app/admin/(authenticated)/layout.tsx
+++ b/src/app/admin/(authenticated)/layout.tsx
@@ -21,7 +21,7 @@ export default function AuthenticatedAdminLayout({
     <Authenticated key="authenticated-admin-layout" loading={<AdminLoading />}>
       <div className="min-h-screen">
         <AdminSidebar />
-        <main className="p-4 md:p-8 lg:p-16">{children}</main>
+        <main className="p-4 pt-16 md:p-8 lg:p-16">{children}</main>
       </div>
     </Authenticated>
   );

--- a/src/app/admin/(authenticated)/page.tsx
+++ b/src/app/admin/(authenticated)/page.tsx
@@ -15,8 +15,10 @@ export const metadata: Metadata = {
 
 export default function AdminDashboard() {
   return (
-    <div className="container mx-auto p-6">
-      <h1 className="text-3xl font-bold mb-6">管理画面ダッシュボード</h1>
+    <div className="container mx-auto p-2 md:p-6">
+      <h1 className="text-2xl md:text-3xl font-bold mb-4 md:mb-6">
+        管理画面ダッシュボード
+      </h1>
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         <Card>
           <CardHeader>

--- a/src/components/admin/Pagination/index.tsx
+++ b/src/components/admin/Pagination/index.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/shadcn/button";
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  goNext: () => void;
+  goPrev: () => void;
+}
+
+/**
+ * ページネーションUI
+ *
+ * totalPages <= 1 の場合は非表示
+ */
+export function Pagination({
+  currentPage,
+  totalPages,
+  goNext,
+  goPrev,
+}: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="flex items-center justify-center gap-3">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={goPrev}
+        disabled={currentPage <= 1}
+      >
+        <ChevronLeft className="h-4 w-4" />
+        <span>前へ</span>
+      </Button>
+      <span className="text-sm text-muted-foreground">
+        {currentPage} / {totalPages}
+      </span>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={goNext}
+        disabled={currentPage >= totalPages}
+      >
+        <span>次へ</span>
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/refine-ui/views/create-view.tsx
+++ b/src/components/refine-ui/views/create-view.tsx
@@ -70,7 +70,7 @@ export const CreateViewHeader = ({
         <Button variant="ghost" size="icon" onClick={back}>
           <ArrowLeftIcon className="h-4 w-4" />
         </Button>
-        <h2 className="text-2xl font-bold">{title}</h2>
+        <h2 className="text-xl md:text-2xl font-bold truncate">{title}</h2>
       </div>
     </div>
   );

--- a/src/components/refine-ui/views/edit-view.tsx
+++ b/src/components/refine-ui/views/edit-view.tsx
@@ -78,7 +78,7 @@ export const EditViewHeader = ({
           <Button variant="ghost" size="icon" onClick={back}>
             <ArrowLeftIcon className="h-4 w-4" />
           </Button>
-          <h2 className="text-2xl font-bold">{title}</h2>
+          <h2 className="text-xl md:text-2xl font-bold truncate">{title}</h2>
         </div>
 
         <div className="flex items-center gap-2">

--- a/src/components/refine-ui/views/list-view.tsx
+++ b/src/components/refine-ui/views/list-view.tsx
@@ -56,8 +56,17 @@ export const ListViewHeader = ({
         </div>
         <Separator className={cn("absolute", "left-0", "right-0", "z-[1]")} />
       </div>
-      <div className={cn("flex", "justify-between", "gap-4", headerClassName)}>
-        <h2 className="text-2xl font-bold">{title}</h2>
+      <div
+        className={cn(
+          "flex",
+          "items-center",
+          "justify-between",
+          "gap-2",
+          "md:gap-4",
+          headerClassName,
+        )}
+      >
+        <h2 className="text-xl md:text-2xl font-bold truncate">{title}</h2>
         {isCreateButtonVisible && (
           <div className="flex items-center gap-2">
             <CreateButton resource={resourceName} />

--- a/src/components/refine-ui/views/show-view.tsx
+++ b/src/components/refine-ui/views/show-view.tsx
@@ -78,7 +78,7 @@ export const ShowViewHeader = ({
           <Button variant="ghost" size="icon" onClick={back}>
             <ArrowLeftIcon className="h-4 w-4" />
           </Button>
-          <h2 className="text-2xl font-bold">{title}</h2>
+          <h2 className="text-xl md:text-2xl font-bold truncate">{title}</h2>
         </div>
 
         <div className="flex items-center gap-2">

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+
+interface UsePaginationResult<T> {
+  paginatedItems: T[];
+  currentPage: number;
+  totalPages: number;
+  goToPage: (page: number) => void;
+  goNext: () => void;
+  goPrev: () => void;
+}
+
+/**
+ * クライアントサイドのページネーションフック
+ *
+ * items が変わったらページ1にリセット
+ */
+export function usePagination<T>(
+  items: T[],
+  pageSize: number,
+): UsePaginationResult<T> {
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
+
+  // items.length が変わったらページ1にリセット
+  const prevLengthRef = useRef(items.length);
+  if (prevLengthRef.current !== items.length) {
+    prevLengthRef.current = items.length;
+    setCurrentPage(1);
+  }
+
+  // 現在のページが totalPages を超えていたら補正
+  const safePage = Math.min(currentPage, totalPages);
+
+  const paginatedItems = useMemo(() => {
+    const start = (safePage - 1) * pageSize;
+    return items.slice(start, start + pageSize);
+  }, [items, safePage, pageSize]);
+
+  const goToPage = useCallback(
+    (page: number) => {
+      setCurrentPage(Math.max(1, Math.min(page, totalPages)));
+    },
+    [totalPages],
+  );
+
+  const goNext = useCallback(() => {
+    setCurrentPage((prev) => Math.min(prev + 1, totalPages));
+  }, [totalPages]);
+
+  const goPrev = useCallback(() => {
+    setCurrentPage((prev) => Math.max(prev - 1, 1));
+  }, []);
+
+  return {
+    paginatedItems,
+    currentPage: safePage,
+    totalPages,
+    goToPage,
+    goNext,
+    goPrev,
+  };
+}

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 interface UsePaginationResult<T> {
   paginatedItems: T[];
@@ -24,7 +24,8 @@ export function usePagination<T>(
 
   const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
 
-  // items.length が変わったらページ1にリセット
+  // items.length が変わったらページ1にリセット（レンダー中のstate調整パターン）
+  // cf. https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
   const prevLengthRef = useRef(items.length);
   if (prevLengthRef.current !== items.length) {
     prevLengthRef.current = items.length;
@@ -34,25 +35,20 @@ export function usePagination<T>(
   // 現在のページが totalPages を超えていたら補正
   const safePage = Math.min(currentPage, totalPages);
 
-  const paginatedItems = useMemo(() => {
-    const start = (safePage - 1) * pageSize;
-    return items.slice(start, start + pageSize);
-  }, [items, safePage, pageSize]);
+  const start = (safePage - 1) * pageSize;
+  const paginatedItems = items.slice(start, start + pageSize);
 
-  const goToPage = useCallback(
-    (page: number) => {
-      setCurrentPage(Math.max(1, Math.min(page, totalPages)));
-    },
-    [totalPages],
-  );
+  const goToPage = (page: number) => {
+    setCurrentPage(Math.max(1, Math.min(page, totalPages)));
+  };
 
-  const goNext = useCallback(() => {
+  const goNext = () => {
     setCurrentPage((prev) => Math.min(prev + 1, totalPages));
-  }, [totalPages]);
+  };
 
-  const goPrev = useCallback(() => {
+  const goPrev = () => {
     setCurrentPage((prev) => Math.max(prev - 1, 1));
-  }, []);
+  };
 
   return {
     paginatedItems,


### PR DESCRIPTION
## 概要

管理画面のイベント一覧・管理者一覧をスマートフォンで見やすくするため、SP（< md）ではカード表示、PC（md ≧）ではテーブル表示にCSS出し分けを実装。クライアントサイドページネーション（1ページ6件）も追加。

## 変更内容

- SP表示時にカード形式で一覧を表示（`md:hidden` / `hidden md:block` で出し分け）
- イベントカード: サムネ48x48 + タイトル + 日付 + ステータスBadge + EventActions
- 管理者カード: イニシャルAvatar + 名前 + メール + ロールBadge + AdminActions
- `usePagination` フック新規作成（クライアントサイド、1ページ6件）
- `Pagination` UIコンポーネント新規作成（前へ/次へ + ページ番号表示）
- `EventsContent` / `AdminsContent` 統合コンポーネント新規作成（useList + SP/PC出し分け + ページネーション管理）
- `EventsTable` / `AdminsTable` をリファクタリング（useList削除、propsでデータ受取に変更）
- Tailwindレスポンシブクラス調整（テーブル列の非表示、レイアウト調整）

## テスト

- `./bin/check` 通過（型チェック + lint + format）
- 375px幅で `/admin/events` カード表示・ページネーション動作確認
- 375px幅で `/admin/admins` カード表示・ページネーション動作確認
- 768px以上でテーブル表示に切り替わることを確認

## スクリーンショット

<!-- UI変更がある場合、スクリーンショットを添付 -->