### PR TITLE
fix: イベント詳細のtypeラベル表示崩れを修正

### DIFF
--- a/src/app/(user)/events/[id]/_components/EventThumbnail.tsx
+++ b/src/app/(user)/events/[id]/_components/EventThumbnail.tsx
@@ -22,7 +22,7 @@ export function EventThumbnail({
   className,
 }: EventThumbnailProps) {
   return (
-    <div className={cn("relative mx-auto md:mx-0", className)}>
+    <div className={cn("relative mx-auto md:mx-0 max-w-sm", className)}>
       <EventImage src={src} alt={alt} />
       <div
         className={cn(

--- a/src/app/(user)/events/[id]/loading.tsx
+++ b/src/app/(user)/events/[id]/loading.tsx
@@ -30,7 +30,7 @@ export default function EventDetailLoading() {
           <Skeleton className="h-8 md:h-10 w-full" />
         </div>
         {/* Thumbnail */}
-        <div className="order-3">
+        <div className="order-3 max-w-sm mx-auto md:mx-0">
           <Skeleton className="w-full aspect-insta" />
         </div>
         {/* Description */}


### PR DESCRIPTION
## Summary
- イベント詳細ページで、BubleLabelが右側に配置された際にサムネイル画像と重ならない問題を修正
- 親コンテナに `max-w-sm` を追加し、画像幅と一致させることでラベルの絶対配置が正しく機能するようにした

## Root Cause
`EventThumbnail` の親 `div` がグリッドセル幅いっぱいに広がる一方、画像は `max-w-sm` で制約されていたため、`absolute -right-3` のラベルが画像の右端ではなく親の右端を基準に配置されていた。

## Test plan
- [ ] イベント詳細ページでラベルが右上/右下に配置される場合、サムネイル画像と正しく重なることを確認
- [ ] SP/PC両方で表示崩れがないことを確認

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)